### PR TITLE
fix: `MockInfo` init in test case

### DIFF
--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -324,6 +324,7 @@ impl Context {
             inputs: self.inputs.clone(),
             cell_deps: self.cell_deps.clone(),
             header_deps: self.header_deps.clone(),
+            extensions: vec![],
         };
         MockTransaction { mock_info, tx }
     }


### PR DESCRIPTION
`MockInfo` struct updated in [ckb_mock_tx_types](https://github.com/nervosnetwork/ckb-standalone-debugger/commit/35e14f13e7daf09c61f9782a1045adb530d9687d).